### PR TITLE
fix progress bar styles

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -35,13 +35,19 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
             this._save = $('[name=save]');
             this._id = $('input[name=id]');
             this._progress = $('<div>', {
-                class: 'hide controls progress progress-striped active'
-            });
-            this._bar = $('<div>', {class:'bar'});
+                class: 'form-group controls progress active'
+            }).hide();
+            this._bar = $('<div>', {
+                class:'progress-bar progress-bar-striped',
+                role:'progressbar',
+                style: 'min-width:2em',
+            }).text('0%');
             this._progress.append(this._bar);
             this._progress.insertAfter(this._url.parent().parent());
-            this._resumeBtn = $('<a>', {class: 'hide btn btn-info controls'}).insertAfter(
-                this._progress).text('Resume Upload');
+            this._resumeBtn = $('<a>', {class: 'btn btn-info controls'})
+                .hide()
+                .insertAfter(this._progress)
+                .text('Resume Upload');
 
             var self = this;
 
@@ -153,7 +159,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                 return false;
             }
 
-            this._setProgressType('info', this._progress);
+            this._setProgressType('info', this._bar);
             this._progress.show('slow');
         },
 
@@ -374,7 +380,6 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                 data_dict,
                 function (data) {
 
-                    self._progress.hide('fast');
                     self._onDisableSave(false);
 
                     if (self._resourceId && self._packageId){
@@ -409,7 +414,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                     self._onHandleError(self.i18n('unable_to_finish'));
                 }
             );
-            this._setProgressType('success', this._progress);
+            this._setProgressType('success', this._bar);
         },
 
         _onDisableSave: function (value) {
@@ -418,12 +423,13 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
 
         _setProgress: function (progress, bar) {
             bar.css('width', progress + '%');
+            bar.text(Math.round(progress) + '%');
         },
 
         _setProgressType: function (type, progress) {
             progress
-                .removeClass('progress-success progress-danger progress-info')
-                .addClass('progress-' + type);
+                .removeClass('progress-bar-success progress-bar-danger progress-bar-info')
+                .addClass('progress-bar-' + type);
         },
 
         _onHandleError: function (msg) {


### PR DESCRIPTION
After spending hours trying to figure out what in the UNHCR theme was breaking this, I tried it on a completely box-fresh CKAN install. This is the "before" behaviour - note the progress bar width percentage increases in dev tools but the div is never actually un-hidden:

![GIFrecord_2020-06-05_123730](https://user-images.githubusercontent.com/6025893/83878543-38b8e200-a734-11ea-95cf-ef307a281fcd.gif)

---

..and here is the behaviour with these changes applied:

![GIFrecord_2020-06-05_123956](https://user-images.githubusercontent.com/6025893/83878560-3f475980-a734-11ea-81ff-d8e85aa18a2e.gif)

I'm not sure if this is broken by a recent change to CKAN, but on an out-of-the box install of 2.8.4, the progress bar just doesn't show.