### PR TITLE
scroll to the top on save

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -279,6 +279,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
             formData.url_type = 'upload';
             var action = formData.id ? 'resource_update' : 'resource_create';
             var url = this._form.attr('action') || window.location.href;
+            window.scrollTo(0,0);
             this.sandbox.client.call(
                 'POST',
                 action,


### PR DESCRIPTION
When we submit the form, if we're scrolled too far down the page, all the "action" - notifications (if they're in the default place), progress bar (once its fixed, see #1 ) - is happening at the top of the screen. This is particularly bad on an install like UNHCR where there are a bunch of extra fields on the resource form so the add button is quite far down the page. This means there is some indication that stuff is happening, but its all going on outside the user's viewport unless they actively scroll to it. Proposed solution: scroll to the top on save.

Before:

![GIFrecord_2020-06-05_125127](https://user-images.githubusercontent.com/6025893/83878825-9f3e0000-a734-11ea-8fd9-d034ae4b0f0e.gif)

---

After:

![GIFrecord_2020-06-05_125326](https://user-images.githubusercontent.com/6025893/83878868-abc25880-a734-11ea-84d9-c69c893e0e9e.gif)

I did consider moving the progress bar to the bottom of the form, but if we're going to move the notifications back to the default place for UNHCR I think this makes more sense.