### PR TITLE
show a more helpful error if validation fails

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -297,9 +297,17 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                     self._onPerformUpload(file);
                 },
                 function (err, st, msg) {
+                    var notification = msg
+                    try {
+                        if (err.responseJSON.error.__type === 'Validation Error') {
+                            notification = self._summariseError(err.responseJSON.error);
+                        }
+                    } catch(e) {
+                        notification = msg;
+                    }
                     self.sandbox.notify(
                         'Error',
-                        msg,
+                        notification,
                         'error'
                     );
                     self._onHandleError('Unable to save resource');
@@ -308,6 +316,15 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
 
         },
 
+        _summariseError: function(error) {
+            return Object.keys(error).map(function (key) {
+                if (key !== '__type') {
+                    return key + ': ' + error[key];
+                }
+            }).filter(function(el) {
+                return el != null;
+            }).join(', ');
+        },
 
         _onPerformUpload: function(file) {
             var id = this._id.val();


### PR DESCRIPTION
This isn't a massive improvement. Because core sets the notification content with `$().text()` we can't inject any HTML here (so we can't pass a `<ul>` of errors for example). There's definitely a lot of scope to do something better/more complicated, but I think this is worth doing as a first stepping stone. An error message that contains some useful information with sub-optimal formatting is better than an error that includes no useful information at all.

Before:

![Screenshot at 2020-06-05 13-15-23](https://user-images.githubusercontent.com/6025893/83878980-de6c5100-a734-11ea-95f8-07873e418181.png)

---

After:

![Screenshot at 2020-06-05 13-14-33](https://user-images.githubusercontent.com/6025893/83878996-e3310500-a734-11ea-8978-534b7615390e.png)
