### PR TITLE
don't display 2 notifications to tell us everything is OK

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -5,8 +5,6 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
         options: {
             cloud: 'S3',
             i18n: {
-                resource_create: _('Resource has been created.'),
-                resource_update: _('Resource has been updated.'),
                 undefined_upload_id: _('Undefined uploadId.'),
                 upload_completed: _('Upload completed. You will be redirected in few seconds...'),
                 unable_to_finish: _('Unable to finish multipart upload')
@@ -296,11 +294,6 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                     self._resourceId = result.id;
 
                     self._id.val(result.id);
-                    self.sandbox.notify(
-                        result.id,
-                        self.i18n(action, {id: result.id}),
-                        'success'
-                    );
                     self._onPerformUpload(file);
                 },
                 function (err, st, msg) {
@@ -401,11 +394,7 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                     self._onDisableSave(false);
 
                     if (self._resourceId && self._packageId){
-                        self.sandbox.notify(
-                            'Success',
-                            self.i18n('upload_completed'),
-                            'success'
-                        );
+                        self._bar.text(self.i18n('upload_completed'))
                         // self._form.remove();
                         if (self._clickedBtn == 'again') {
                             this._redirect_url = self.sandbox.url(


### PR DESCRIPTION
refs https://github.com/okfn/ckanext-unhcr/issues/369

* If everything is working, we don't need to fire multiple success notifications. The progress bar is enough to give a visual indicator "stuff is happening"
* Display notifications only if something went wrong
* Show "You will be redirected in a few seconds.." after 100% on the progress bar

This came up in a conversation with Mariann after you dropped from the EDD spec call @amercader . 

This one might not be suitable for an upstream contribution, but we do want it for RIDL.