### PR TITLE
fix infinite loop uploading to S3

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -244,7 +244,7 @@ class ResourceCloudStorage(CloudStorage):
                 )
             else:
                 self.container.upload_object_via_stream(
-                    self.file_upload,
+                    iterator=(i for i in self.file_upload),
                     object_name=self.path_from_filename(
                         id,
                         self.filename


### PR DESCRIPTION
Turn `self.file_upload` into a generator (which will eventually raise `StopIteration`). Passing `self.file_upload` directly causes an infinite loop in python2